### PR TITLE
Clean/Disable Output Buffering

### DIFF
--- a/src/FileDownload.php
+++ b/src/FileDownload.php
@@ -77,7 +77,7 @@ class FileDownload
         header("Content-Transfer-Encoding: binary");
         header("Content-Length: {$this->getFileSize()}");
 
-        @ob_clean();
+        @ob_end_clean();
         
         $meta = stream_get_meta_data($this->filePointer);
         


### PR DESCRIPTION
Use ob_end_clean() to clear/disable the output buffer as to not exhaust PHP memory for large files.
